### PR TITLE
chore(terraform): agregar archivo de estado inicial

### DIFF
--- a/terraform.tfstate
+++ b/terraform.tfstate
@@ -1,9 +1,9 @@
 {
-  "version": 4,
-  "terraform_version": "1.13.2",
-  "serial": 1,
-  "lineage": "306907f1-1997-d5f7-1c69-811126cc7aa1",
-  "outputs": {},
-  "resources": [],
-  "check_results": null
+  "version": 4,    #Versión del formato de estado de Terraform
+  "terraform_version": "1.13.2", #Versión de Terraform que generó este estado
+  "serial": 1, #Contador de cambios en el estado
+  "lineage": "306907f1-1997-d5f7-1c69-811126cc7aa1",  #Identificador único del estado
+  "outputs": {}, #No hay outputs definidos todavía
+  "resources": [], #No se han aplicado recursos aún
+  "check_results": null  #No hay resultados de comprobaciones
 }


### PR DESCRIPTION
Se agrega el archivo terraform.tfstate generado con Terraform 1.13.2. El estado inicial no contiene recursos ni salidas (outputs),  sirve como punto de partida para futuras ejecuciones y despliegues.