### PR TITLE
feat(terraform): agregar recurso docker_container para Nginx

### DIFF
--- a/terraform/nginx.tf
+++ b/terraform/nginx.tf
@@ -1,10 +1,10 @@
 
 resource "docker_container" "nginx" {
-  name  = "nginx-${terraform.workspace}"
-  image = "nginx:stable-perl"
+  name  = "nginx-${terraform.workspace}" #Nombre dinámico según el workspace actual
+  image = "nginx:stable-perl"  #Imagen oficial de Nginx (tag stable-perl)
 
   ports {
-    internal = 80
-    external = var.nginx_external_port[terraform.workspace]
+    internal = 80  #Puerto interno del contenedor
+    external = var.nginx_external_port[terraform.workspace]  #Puerto externo definido por variable, por workspace
   }
 }


### PR DESCRIPTION
Se define un contenedor Docker basado en la imagen oficial nginx:stable-perl. El nombre del contenedor se ajusta dinámicamente según el workspace de Terraform. El puerto externo se obtiene de la variable nginx_external_port para cada entorno.