### PR TITLE
feat(terraform): agregar outputs con URLs de servicios locales

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,20 +1,20 @@
 
 output "grafana_url" {
-  value = "http://localhost:${var.web_server_ports_external}"
+  value = "http://localhost:${var.web_server_ports_external}"  # URL base de Grafana
 }
 
 output "app1_url" {
-  value = "http://localhost:${var.web_server_ports_external + 1}"
+  value = "http://localhost:${var.web_server_ports_external + 1}"  # URL App1 (+1 al puerto base)
 }
 
 output "app2_url" {
-  value = "http://localhost:${var.web_server_ports_external + 2}"
+  value = "http://localhost:${var.web_server_ports_external + 2}"  # URL App2 (+2 al puerto base)
 }
 
 output "app3_url" {
-  value = "http://localhost:${var.web_server_ports_external + 3}"
+  value = "http://localhost:${var.web_server_ports_external + 3}"  # URL App3 (+3 al puerto base)
 }
 
 output "nginx_url" {
-  value = "http://localhost:${var.nginx_external_port[terraform.workspace]}"
+  value = "http://localhost:${var.nginx_external_port[terraform.workspace]}"  # URL Nginx según workspace
 }


### PR DESCRIPTION
Se definen salidas (outputs) que exponen las URLs locales de:
- Grafana
- App1, App2, App3 (con puertos incrementales a partir de web_server_ports_external)
- Nginx (puerto dinámico según workspace)

Estos outputs facilitan el acceso directo a los servicios una vez desplegados, permitiendo consultar rápidamente las direcciones en la salida del plan/apply.